### PR TITLE
enable gray image

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The params details please check [Aliyun OSS image preocess doc](https://help.ali
 - [x] bright
 - [x] sharpen
 - [x] contrast
+- [x] gray
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fsongjiayang%2Fimagecloud.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fsongjiayang%2Fimagecloud?ref=badge_large)

--- a/api/handler/image.go
+++ b/api/handler/image.go
@@ -92,8 +92,8 @@ func (i *Image) process(c *gin.Context, args *types.CmdArgs) {
 	}
 	i.logger.Log("msg", "image process", "cmds", pQuery)
 
-	// add defautl jpg export params
-	ep := vips.NewDefaultJPEGExportParams()
+	// default export params with original format
+	ep := vips.NewDefaultExportParams()
 	ep.Quality = 75
 	ep.Format = args.Img.Metadata().Format
 	args.Ep = ep

--- a/internal/image/processor/gray.go
+++ b/internal/image/processor/gray.go
@@ -1,0 +1,30 @@
+package processor
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/davidbyttow/govips/v2/vips"
+
+	"github.com/songjiayang/imagecloud/internal/image/metadata"
+	"github.com/songjiayang/imagecloud/internal/image/processor/types"
+)
+
+type Gray string
+
+func (*Gray) Process(args *types.CmdArgs) (info *metadata.Info, err error) {
+	if len(args.Params) != 1 {
+		return nil, errors.New("invalid gray params")
+	}
+
+	value, err := strconv.Atoi(args.Params[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if value == 1 {
+		err = args.Img.ToColorSpace(vips.InterpretationBW)
+	}
+
+	return
+}

--- a/internal/image/processor/gray_test.go
+++ b/internal/image/processor/gray_test.go
@@ -1,0 +1,28 @@
+package processor
+
+import (
+	"testing"
+)
+
+func TestGray(t *testing.T) {
+	cases := []TestCase{
+		{
+			Name:      "invalid params",
+			Image:     "01.jpg",
+			Params:    []string{},
+			ExpectErr: "invalid gray params",
+		},
+		{
+			Name:   "enable gray",
+			Image:  "01.jpg",
+			Params: []string{"1"},
+		},
+		{
+			Name:   "disable gray",
+			Image:  "01.jpg",
+			Params: []string{"0"},
+		},
+	}
+
+	runTableTest(cases, t, new(Gray))
+}

--- a/internal/image/processor/processor.go
+++ b/internal/image/processor/processor.go
@@ -36,6 +36,7 @@ func init() {
 			"bright":          new(Bright),
 			"sharpen":         new(Sharpen),
 			"contrast":        new(Contrast),
+			"gray":            new(Gray),
 		}
 	})
 }


### PR DESCRIPTION
`x-oss-process=image/gray,1` output is:

![image](https://github.com/imagecodex/imagecloud/assets/1459834/a58c0c0f-8a7d-452a-b81a-ff61b21406a2)
